### PR TITLE
fix: emby-select&emby-itemscontainer on AndroidTV

### DIFF
--- a/Emby.CustomCssJS/Configuration/customcssjs.html
+++ b/Emby.CustomCssJS/Configuration/customcssjs.html
@@ -59,7 +59,7 @@
                     <br>
 
 
-                    <div id="customcssjsTemplate" class="listItem focusable listItem-hoverable listItem-withContentWrapper hide">
+                    <div id="customcssjsTemplate" class="listItem listItem-hoverable listItem-withContentWrapper hide">
                         <div class="listItem-content listItemContent-touchzoom listItem-border">
                             <i class="md-icon listItemIcon customcssjsSource"></i>
                             <i class="md-icon listItemIcon customcssjsState"></i>

--- a/Emby.CustomCssJS/Configuration/customcssjs.js
+++ b/Emby.CustomCssJS/Configuration/customcssjs.js
@@ -38,6 +38,10 @@ define([
       let url = Dashboard.getConfigurationResourceUrl('customcssjs_update').split("/");
       embyRouter.show(url.pop() + `&cname=${name}&type=${type}&source=${source}&forceflag=${forceflag}`);
     }
+
+    function scrollByEvent(e) {
+      e.target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
   
     function renderConfiguration(config, type, source) {
       let listNode = view.querySelector(`#custom${type}List${source}`);
@@ -111,12 +115,17 @@ define([
           editBtnNode.addEventListener("click", function () {
             update(detail.name, type, source, forceflag)
           });
+          editBtnNode.addEventListener("focus", scrollByEvent);
           // set delete button
           let delBtnNode = templateNode.querySelector(".customcssjsDelBtn");
-          source === "Server" ? delBtnNode.remove()
-            : delBtnNode.addEventListener("click", function () {
-              del(detail.name, type);
-            });
+          if (source === "Server") {
+            delBtnNode.remove();
+          } else {
+              delBtnNode.addEventListener("click", function () {
+                del(detail.name, type);
+              });
+              delBtnNode.addEventListener("focus", scrollByEvent);
+          }
           // append to list
           view.querySelector(`#custom${type}List${source}Description`).classList.remove("hide");
           listNode.appendChild(templateNode);

--- a/Emby.CustomCssJS/Configuration/customcssjs_provider.html
+++ b/Emby.CustomCssJS/Configuration/customcssjs_provider.html
@@ -42,7 +42,7 @@
                     <br>
 
 
-                    <div id="customcssjsTemplate" class="listItem focusable listItem-hoverable listItem-withContentWrapper hide">
+                    <div id="customcssjsTemplate" class="listItem listItem-hoverable listItem-withContentWrapper hide">
                         <div class="listItem-content listItemContent-touchzoom listItem-border">
                             <i class="listItemIcon md-icon customcssjsState"></i>
                             <div class="listItemBody itemAction">

--- a/Emby.CustomCssJS/Configuration/customcssjs_provider.js
+++ b/Emby.CustomCssJS/Configuration/customcssjs_provider.js
@@ -41,6 +41,10 @@ define([
       embyRouter.show(url.pop() + `&cname=${name}&type=${type}`);
     }
 
+    function scrollByEvent(e) {
+      e.target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
     function renderConfiguration(config, type) {
       let listNode = view.querySelector(`#custom${type}List`);
       while (listNode.childNodes.length > 0) {
@@ -95,11 +99,13 @@ define([
           delBtnNode.addEventListener("click", function () {
             del(detail.name, type);
           });
+          delBtnNode.addEventListener("focus", scrollByEvent);
           // set edit button
           let editBtnNode = templateNode.querySelector(".customcssjsEditBtn");
           editBtnNode.addEventListener("click", function () {
             update(detail.name, type)
           });
+          editBtnNode.addEventListener("focus", scrollByEvent);
           // append to list
           listNode.appendChild(templateNode);
         }

--- a/Emby.CustomCssJS/Configuration/customcssjs_provider_update.html
+++ b/Emby.CustomCssJS/Configuration/customcssjs_provider_update.html
@@ -28,11 +28,13 @@
                             <br>
 
                             <label class="inputLabel" for="customjscssState">${State:}</label>
-                            <select id="customjscssState" is="emby-select" class="emby-select">
-                                <option value="off">${Off}</option>
-                                <option value="on">${On}</option>
-                                <option value="forced_on">${Forced On}</option>
-                            </select>
+                            <label class="selectLabel">
+                                <select id="customjscssState" is="emby-select" class="emby-select emby-select-wrapper">
+                                    <option value="off">${Off}</option>
+                                    <option value="on">${On}</option>
+                                    <option value="forced_on">${Forced On}</option>
+                                </select>
+                            </label>
                             <br>
 
                             <div class="warningBanner">

--- a/Emby.CustomCssJS/Configuration/customcssjs_update.html
+++ b/Emby.CustomCssJS/Configuration/customcssjs_update.html
@@ -29,10 +29,12 @@
                             <div id="customjscssStateDiv">
                                 <br>
                                 <label class="inputLabel" for="customjscssState">${State:}</label>
-                                <select id="customjscssState" is="emby-select" class="emby-select">
-                                    <option value="off">${Off}</option>
-                                    <option value="on">${On}</option>
-                                </select>
+                                <label class="selectLabel">
+                                    <select id="customjscssState" is="emby-select" class="emby-select emby-select-wrapper">
+                                        <option value="off">${Off}</option>
+                                        <option value="on">${On}</option>
+                                    </select>
+                                </label>
                             </div>
                             <br>
 


### PR DESCRIPTION
1.只是`Emby for Android`的`TV布局`下的修复
2.`Emby for Android TV_xxxg`这个`Kotlin native`的`TV 专用版`无`Web`环境，所以不涉及